### PR TITLE
Add cloud.gov deploy guide

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -77,6 +77,9 @@ navigation:
   - text: Included with Federalist
     url: included-with-federalist/
     internal: true
+  - text: Deploying to cloud.gov
+    url: deploying-to-cloud-gov/
+    internal: true
   - text: Running Federalist locally
     url: running-federalist-locally/
     internal: true

--- a/_config.yml
+++ b/_config.yml
@@ -77,8 +77,11 @@ navigation:
   - text: Included with Federalist
     url: included-with-federalist/
     internal: true
-  - text: Deploying to cloud.gov
-    url: deploying-to-cloud-gov/
+  - text: Deploying Federalist
+    url: deploying-federalist/
+    internal: true
+  - text: cloud.gov Setup
+    url: cloud-gov-setup/
     internal: true
   - text: Running Federalist locally
     url: running-federalist-locally/

--- a/pages/how-federalist-works/cloud-gov-setup.md
+++ b/pages/how-federalist-works/cloud-gov-setup.md
@@ -1,9 +1,9 @@
 ---
-title: Deploying to cloud.gov
+title: cloud.gov Setup
 parent: How Federalist Works
 ---
 
-## Deploying Federalist to cloud.gov's GovCloud environment
+## Configuring Federalist in cloud.gov's GovCloud environment
 
 Federalist is built to be deployed to the [GovCloud](https://cloud.gov/docs/apps/govcloud/) region in [cloud.gov](https://cloud.gov/docs/). This guide is targeted at anyone who wishes to deploy the entire Federalist system to cloud.gov from the ground up, or anyone who wishes to get a better grasp of how the system is architected by looking at how it is deployed.
 

--- a/pages/how-federalist-works/deploying-federalist.md
+++ b/pages/how-federalist-works/deploying-federalist.md
@@ -1,0 +1,55 @@
+---
+title: Deploying Federalist
+parent: How Federalist Works
+---
+
+## Deploying Federalist from TravisCI
+
+This guide covers how the deployment process for Federalist and Federalist Builder works.
+In order to understand the process for Federalist Docker Build and Federalist Registry, see [the cloud.gov setup guide]({{site.baseurl}}/pages/how-federalist-works/cloud-gov-setup/).
+
+Federalist is deployed by [TravisCI](https://docs.travis-ci.com/user/deployment/).
+Federalist and Federalist Builder are configured such that changes to the master branch are deployed to production and changes to the staging branch are deployed to staging.
+In both repos this configuration lives in the [.travis.yml](https://docs.travis-ci.com/user/customizing-the-build) file in the project root.
+
+Both projects use a file at `scripts/deploy-travis.sh` to run the actual deploy.
+These scripts authenticate with cloud.gov using a [cloud.gov deploy user](https://cloud.gov/docs/apps/continuous-deployment/#deployer-account).
+Despite some minor differences, both of these scripts do essentially the same thing:
+
+0. Check the current branch and use it to determine which space to deploy to
+0. Install Autopilot for cf-cli (used for zero downtime deploys)
+0. Use `cf login` to authenticate the deploy user
+0. Do a zero downtime push of the application
+
+It is worth noting that the environment for these scripts is set in the `.travis.yml` for the following:
+
+- `CF_API`: The Cloud Foundry API endpoint, for example `api.cloud.gov`
+- `CF_USERNAME`: The username for the cloud.gov deploy user
+- `CF_ORGANIZATION`: The Cloud Foundry org where the app is deployed
+- `CF_PASSWORD`: An [environment](https://docs.travis-ci.com/user/environment-variables/#Defining-encrypted-variables-in-.travis.yml) variable for the cloud.gov deploy user's password
+
+## Zero downtime deploys
+
+Federalist has high availability requirements because it needs to be up to receive GitHub webhook and build status requests.
+Because of this, the [autopilot](https://cloud.gov/docs/apps/production-ready/#zero-downtime-deploy) Cloud Foundry CLI plugin is used so the app can be deployed without downtime.
+
+Zero downtime deploys work by:
+
+0. Renaming the app to `<appname>-venerable`, for example `federalist-venerable`
+0. Pushing a new app with the old app's name
+0. When the new app is started, routing requests to the new app and deleting the venerable app
+
+#### Cleanup after a failed deploy
+
+If autopilot fails to deploy the new app, it exits and does not clean up after itself.
+So after a failed deploy there will be a stopped app named `<appname>` and a running app named `<appname>-venerable` fielding requests.
+This is by design so that a failed deploy does not cause the app to go down.
+
+The downside of this setup is that all future deploys will fail since there will be a name collision on `<appname>-venerable`.
+As a result, the failed deploy will need to be cleaned up before another deploy can succeed.
+
+To cleanup after a failed deploy:
+
+0. Delete the new app. For the main Federalist app that would be `federalist`.
+0. Rename the venerable app to the name of the new app. For example, rename `federalist-venerable` to `federalist`.
+0. Start a build on Travis to re-deploy.

--- a/pages/how-federalist-works/deploying-to-cloud-gov.md
+++ b/pages/how-federalist-works/deploying-to-cloud-gov.md
@@ -198,7 +198,17 @@ docker inspect federalist-registry.fr.cloud.gov/federalist-docker-build
 
 ## Deploying build containers
 
-TODO: Describe how to deploy a build container
+Federalist's "build containers" are cloud.gov apps running with the `federalist-docker-build` image. The app needs to run without a healthcheck since it is not fitted to respond to HTTP requests.
+
+To push the app use `cf push`:
+
+```shell
+cf push federalist-docker-build-staging-1 --no-route -u none -o "federalist-registry.fr.cloud.gov/federalist-docker-build"
+```
+
+The first time the app is pushed it may fail to start. That is okay. The app cannot stand on its own without an environment provided by federalist / federalist-builder. It will be restarted with a valid environment when federalist-builder schedules a build on it.
+
+Note that it is possible to push multiple build containers, as long as they have unique names.
 
 ## Provisioning AWS resources
 

--- a/pages/how-federalist-works/deploying-to-cloud-gov.md
+++ b/pages/how-federalist-works/deploying-to-cloud-gov.md
@@ -261,7 +261,29 @@ At this time cloud.gov does not have an SQS service broker. The SQS queue will n
 
 ## Deploying federalist-builder
 
-TODO: Describe how to deploy federalist-builder
+Note: federalist-builder is built to be [deployed from TravisCI](https://docs.travis-ci.com/user/deployment). The instructions for manually deploying federalist-builder are described below and are necessary for the initial deploy, but subsequent deploys should happen on Travis.
+
+The first step to deploy federalist-builder is to configure the environment. The app's [manifest.yml](https://github.com/18F/federalist-builder/blob/master/manifest.yml) set's the app's environment. The manifest sets environment variables directly for non-secret configs. For secret configs it binds user-provided services.
+
+federalist-builder has 2 user provided services that must be created before deploying in order for the app to work.
+
+The first is `federalist-ew-sqs-user` which has the following values:
+
+```yaml
+access_key: <AWS ACCESS KEY FOR SQS QUEUE>
+secret_key: <AWS SECRET KEY FOR SQS QUEUE>
+```
+
+The second is `federalist-deploy-user` which has the following values:
+
+```yaml
+DEPLOY_USER_USERNAME: <THE USERNAME OF THE FEDERALIST DEPLOY USER>
+DEPLOY_USER_PASSWORD: <THE PASSWORD OF THE FEDERALIST DEPLOY USER>
+```
+
+The user provided services can be created with [Cloud Foundry CLI](https://docs.cloudfoundry.org/devguide/services/user-provided.html#create).
+
+Once the user provided services are created deploying is a simple as running `cf push`.
 
 ## Deploying federalist
 

--- a/pages/how-federalist-works/deploying-to-cloud-gov.md
+++ b/pages/how-federalist-works/deploying-to-cloud-gov.md
@@ -281,10 +281,38 @@ DEPLOY_USER_USERNAME: <THE USERNAME OF THE FEDERALIST DEPLOY USER>
 DEPLOY_USER_PASSWORD: <THE PASSWORD OF THE FEDERALIST DEPLOY USER>
 ```
 
-The user provided services can be created with [Cloud Foundry CLI](https://docs.cloudfoundry.org/devguide/services/user-provided.html#create).
+The user provided services can be created with the [Cloud Foundry CLI](https://docs.cloudfoundry.org/devguide/services/user-provided.html#create).
 
 Once the user provided services are created deploying is a simple as running `cf push`.
 
 ## Deploying federalist
 
-TODO: Describe how to deploy federalist core
+Note: federalist-build is built to be [deployed from TravisCI](https://docs.travis-ci.com/user/deployment). The instructions for manually deploying federalist are described below and are necessary for the initial deploy, but subsequent deploys should happen on Travis.
+
+The first step to deploy federalist-builder is to configure the environment. The app's [manifest.yml](https://github.com/18F/federalist-builder/blob/master/manifest.yml) or [staging_manifest.yml](https://github.com/18F/federalist-builder/blob/master/staging_manifest.yml) set's the app's environment. The manifest sets environment variables directly for non-secret configs. For secret configs it binds user-provided services.
+
+The manifest specifies the following services which are provided by cloud.gov by cloud.gov service brokers:
+
+- `federalist-production-rds` / `federalist-staging-rds`
+- `federalist-production-rds` / `federalist-staging-redis`
+- `federalist-production-rds` / `federalist-staging-s3`
+
+In additional, there's a user provided service named `federalist-production-env` or `federalist-staging-env` depending on the environment. This user provided service should be created with the following values:
+
+```yaml
+FEDERALIST_AWS_BUILD_KEY: <THE AWS ACCESS KEY FOR THE SQS QUEUE>
+FEDERALIST_AWS_BUILD_SECRET: <THE AWS SECRET KEY FOR THE SQS QUEUE>
+FEDERALIST_BUILD_CALLBACK: <CALLBACK URL FOR WHEN BUILDS ARE COMPLETE>
+FEDERALIST_BUILD_TOKEN: <SECRET FOR AUTHENTICATING BUILD CALLBACK>
+FEDERALIST_SESSION_SECRET": <SECRET FOR THE SAILS SESSION STORE>
+FEDERALIST_SQS_QUEUE: <URL FOR SQS QUEUE>
+GITHUB_CLIENT_CALLBACK_URL: <OAUTH CALLBACK URL FOR GITHUB AUTH>
+GITHUB_CLIENT_ID: <CLIENT ID FOR GITHUB AUTH>
+GITHUB_CLIENT_SECRET" <CLIENT SECRET FOR GITHUB AUTH>
+GITHUB_WEBHOOK_SECRET: <SECRET FOR SIGNING GITHUB WEBHOOKS>
+GITHUB_WEBHOOK_URL: <URL FOR GITHUB WEBHOOKS TO CALLBACK TO>
+```
+
+The user provided service can be created with the [Cloud Foundry CLI](https://docs.cloudfoundry.org/devguide/services/user-provided.html#create).
+
+Once the user provided services are created deploying is a simple as running `cf push`.

--- a/pages/how-federalist-works/deploying-to-cloud-gov.md
+++ b/pages/how-federalist-works/deploying-to-cloud-gov.md
@@ -1,0 +1,220 @@
+---
+title: Deploying to cloud.gov
+parent: How Federalist Works
+---
+
+## Deploying Federalist to cloud.gov's GovCloud environment
+
+Federalist is built to be deployed to the [GovCloud](https://cloud.gov/docs/apps/govcloud/) region in [cloud.gov](https://cloud.gov/docs/). This guide is targeted at anyone who wishes to deploy the entire Federalist system to cloud.gov from the ground up, or anyone who wishes to get a better grasp of how the system is architected by looking at how it is deployed.
+
+Before reading this guide, it may be helpful to refer to [How Federalist Works](http://localhost:4000/pages/how-federalist-works/) to understand what components make up the Federalist architecture and how they are interrelated.
+
+A Federalist deploy comprises of the following steps:
+
+- Deploy a private registry
+- Pushing a federalist-docker-build image to the registry
+- Deploying build containers
+- Provisioning AWS resources
+- Deploying federalist-builder
+- Deploying federalist
+
+## Deploying a private registry
+
+Federalist's private registry stores the image that Federalist uses for its build containers. Under the hood it is a [private Docker registry](https://docs.docker.com/registry/deploying/) using an [S3 storage driver](https://docs.docker.com/registry/storage-drivers/s3/) with [read-only](https://docs.docker.com/registry/configuration/#/read-only-mode) mode enabled.
+
+Push a registry to cloud.gov using the `library/registry:2` image:
+
+```shell
+cf push federalist-registry -o library/registry:2
+```
+
+The registry needs an S3 bucket in which to store images. To this end a S3 service can be created:
+
+```shell
+cf create-service s3 basic federalist-registry-s3
+```
+
+After the registry and the S3 bucket are both up and running the registry's environment will need to be configured such that the registry uses the S3 bucket as a storage backend and is in read-only mode. This can be done by setting the registry [environment](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html) as such:
+
+```yaml
+REGISTRY_STORAGE: s3
+REGISTRY_STORAGE_S3_ACCESSKEY: <ACCESS KEY FOR S3 SERVICE>
+REGISTRY_STORAGE_S3_SECRETKEY: <SECRET KEY FOR S# SERVICE>
+REGISTRY_STORAGE_S3_BUCKET: <BUCKET NAME FOR S3 SERVICE>
+REGISTRY_STORAGE_S3_REGION: us-gov-west-1
+REGISTRY_STORAGE_MAINTENANCE_READONLY: enabled: true
+```
+
+After setting the environment, the registry will need to be restaged to use the new configs:
+
+```shell
+cf restage federalist-registry
+```
+
+## Pushing a federalist-docker-build image to the registry
+
+Unfortunately pushing an image to the private registry is not as simple as building the image and pushing it to the registry. To push an image you must follow the following steps:
+
+- Build the federalist-docker-build image
+- Scan the federalist-docker-build image
+- Push the federalist-docker-build image
+
+### Building the image
+
+The federalist-docker-build image can be built with docker. Clone the repo, cd into it and run `docker build`.
+
+```shell
+docker build --no-cache --tag federalist-docker-build .
+```
+
+The image should now appear in the list when you run `docker images`.
+
+### Scanning the image
+
+Before the image can be pushed to the registry, it will need to be scanned by [Clair](https://github.com/coreos/clair). The steps to do this are:
+
+- Set some shell variables
+- Start up Clair with Docker and wait for vulnerability updates
+- Use Clair CLI tool to scan the image
+
+#### Set some shell variables
+
+Clair's CLI tool copies the image to a `tmp` directory where Clair picks it up. In order for this to work, you need to change the value of the `TMPDIR` variable to `/tmp`
+
+``` shell
+export TMPDIR=/tmp
+```
+
+Additionally, if you do not have your `GOPATH` set, you'll need to set that. [Here is some documentation on how to set `GOPATH`](https://golang.org/doc/code.html#GOPATH).
+
+#### Start up Clair with Docker and wait for vulnerability updates
+
+We recommend starting Clair with [Docker Compose](https://docs.docker.com/compose/). Here is an example `docker-compose.yml` for preparing Clair to scan `federalist-docker-build`:
+
+``` yaml
+version: '2'
+services:
+  postgres:
+    container_name: clair_postgres
+    image: postgres:latest
+    environment:
+      POSTGRES_PASSWORD: password
+
+  clair:
+    container_name: clair_clair
+    image: quay.io/coreos/clair
+    environment:
+      - "TMPDIR=/tmp"
+    depends_on:
+      - postgres
+    ports:
+      - "6060-6061:6060-6061"
+    links:
+      - postgres
+    volumes:
+      - /tmp:/tmp
+      - ./clair_config:/config
+    command: [-config, /config/config.yaml]
+```
+
+Clair will look for a config file in `./clair_config/config`. We recommend using [Clair's example config](https://github.com/coreos/clair/blob/master/config.example.yaml):
+
+``` shell
+curl -L https://raw.githubusercontent.com/coreos/clair/v1.2.2/config.example.yaml -o ./config/config.yaml
+```
+
+Once those parts are in place. Clair can be started with Docker Compose. It takes Clair a while to update it's vulnerability definitions. Give it a few hours or your scan results will come up empty.
+
+To start:
+
+``` shell
+docker-compose up
+```
+
+#### Use Clair CLI tool to scan the image
+
+To actually scan the image we'll use the [Cliar CLI Tool](https://github.com/coreos/clair/tree/master/contrib/analyze-local-images).
+
+First install the CLI tool:
+
+``` shell
+go get -u github.com/coreos/clair/contrib/analyze-local-images
+```
+
+Then use it to scan your image. Here `<IMAGE ID>` is the image ID for `federalist-docker-build` found by running `docker images`:
+
+``` shell
+analyze-local-images <IMAGE ID>
+```
+
+It can take a while, but it should get back to you with a report about whatever vulnerabilities it finds. Cross-reference the list of vulnerabilities with the list in the POAM and add any vulnerabilities that are missing from the POAM.
+
+### Pushing the image
+
+Since the registry in cloud.gov is in read-only mode, it is not possible to push an image to it directly. In order to push an image to the registry a local registry with the same S3 storage driver is started and the image is pushed to that. The image is then saved in the S3 bucket where it is available to the remote registry.
+
+We recommend using [Docker Compose](https://docs.docker.com/compose/) to run the local registry. To use Docker Compose you'll need to create a `docker-compose.yml` file. Here is an example of what a `docker-compose.yml` file would look like for a local registry:
+
+```yaml
+registry:
+  restart: always
+  image: registry:2
+  ports:
+    - 5000:5000
+  environment:
+    REGISTRY_STORAGE: s3
+    REGISTRY_STORAGE_S3_ACCESSKEY: <ACCESS KEY FOR S3 SERVICE>
+    REGISTRY_STORAGE_S3_SECRETKEY: <SECRET KEY FOR S# SERVICE>
+    REGISTRY_STORAGE_S3_BUCKET: <BUCKET NAME FOR S3 SERVICE>
+    REGISTRY_STORAGE_S3_REGION: us-gov-west-1
+```
+
+After creating a `docker-compose.yml`, the registry can be started:
+
+```shell
+docker-compose up
+```
+
+By default the registry runs at `localhost:5000`. To push an image to the registry it will need to be tagged it with the URL for the local registry:
+
+```shell
+docker tag federalist-docker-build localhost:5000/federalist-docker-build
+```
+
+Finally, the image can be pushed to the local registry:
+
+```
+docker push localhost:5000/federalist-docker-build
+```
+
+Now the image should be available from the remote registry as `<remote-registry-url>/federalist-docker-build`.
+
+To confirm that this worked you can pull the image from the remote registry and inspect it:
+
+```shell
+docker pull federalist-registry.fr.cloud.gov/federalist-docker-build
+docker inspect federalist-registry.fr.cloud.gov/federalist-docker-build
+```
+
+## Deploying build containers
+
+TODO: Describe how to deploy a build container
+
+## Provisioning AWS resources
+
+The next pieces of Federalist that need to be deployed will depend on certain AWS resources. That makes this a good time to provision the AWS resources that are needed:
+
+- An RDS instance for the database
+- A Redis instance for the session store
+- An SQS queue for build messages
+- A CloudFront distribution to serve as a CDN and provide support custom URLs.
+
+TODO: Describe how to provision each resource
+
+## Deploying federalist-builder
+
+TODO: Describe how to deploy federalist-builder
+
+## Deploying federalist
+
+TODO: Describe how to deploy federalist core


### PR DESCRIPTION
This PR adds a guide that covers deploying to cloud.gov's GovCloud environment.

~~Right now it only has information about managing / scanning the images but more will come.~~