### PR TITLE
Add note that Federalist custom URL setting must be changed

### DIFF
--- a/pages/how-federalist-works/custom-urls.md
+++ b/pages/how-federalist-works/custom-urls.md
@@ -14,6 +14,7 @@ To get the URLs and HTTPS to work for your production site, there are a few step
  - The Federalist team uses the cloud.gov CloudFront broker to set up a distribution for a given URL.
   - If a cloud.gov customer (not required to use Federalist), you do this by navigating to your org/space and doing this command `cf create-service cdn-route cdn-route YOUR.URL.gov-route -c '{"domain": "YOUR.URL.gov", "origin": "bucketname.s3-website-us-gov-west-1.amazonaws.com", "path": "/site/org/repo-name", "insecure_origin": true}'`
  - You, our partner, set your DNS records to delegate the subdomain to a CloudFront distribution such as d2oezh1w8w4o1u.cloudfront.net provided by the route command above with a CNAME.
+ - Modify your site's Federalist's configuration with the custom URL to ensure assets and CSS are configured appropiately for the custom URL.
  - The site is then served from the CloudFront broker with automatic HTTPS. You retain control over the DNS settings.
  
 Here's a [specific GitHub issue](https://github.com/18F/federalist/issues/551#issuecomment-255841203) with instructions from a successful migration. Note that the HTTPS certifications are managed automatically by the broker using [Let's Encrypt](https://en.wikipedia.org/wiki/Let%27s_Encrypt), which means there is no cost for the HTTPS certificate for you or 18F.


### PR DESCRIPTION
One question: what does this change do? Do the assets go into a different S3 folder, or does Jekyll tell a component browser to look for them at a different URL?