### PR TITLE
Update docker-compose.yml example

### DIFF
--- a/pages/how-federalist-works/cloud-gov-setup.md
+++ b/pages/how-federalist-works/cloud-gov-setup.md
@@ -97,12 +97,14 @@ services:
   postgres:
     container_name: clair_postgres
     image: postgres:latest
+    restart: unless-stopped
     environment:
       POSTGRES_PASSWORD: password
 
   clair:
     container_name: clair_clair
     image: quay.io/coreos/clair
+    restart: unless-stopped
     environment:
       - "TMPDIR=/tmp"
     depends_on:


### PR DESCRIPTION
This file updates the docker-compose.yml example in the "cloud.gov Setup" guide.

For background on this look at coreos/clair#284.