### PR TITLE
Document how to use Node with Federalist

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -77,6 +77,9 @@ navigation:
   - text: Included with Federalist
     url: included-with-federalist/
     internal: true
+  - text: Node on Federalist
+    url: node-on-federalist/
+    internal: true
   - text: Deploying Federalist
     url: deploying-federalist/
     internal: true

--- a/pages/how-federalist-works/node-on-federalist.md
+++ b/pages/how-federalist-works/node-on-federalist.md
@@ -1,0 +1,46 @@
+---
+title: Node on Federalist
+parent: How Federalist Works
+---
+
+*Note that the features described in this document are experimental and are only available in Federalist's GovCloud environment.*
+
+Federalist supports using node and npm to build parts of your site before the build engine starts its work.
+This is helpful for doing things like compiling a site's assets, or employing a build tool such as [Fractal](https://github.com/frctl/fractal).
+
+## The Federalist NPM script
+
+Before Federalist starts the build engine, it checks for a package.json file.
+If it finds one, it will run `npm install`.
+Additionally, if the package.json provides a script named `federalist`, the build engine will run this script.
+This enables Federalist users to add Javascript dependencies to their site, and run a script to prepare the site for the build engine.
+
+Here's an example package.json for a site that uses Webpack:
+
+```json
+{
+  "name": "Webpack example",
+  "version": "1.0.0",
+  "description": "An example Federalist site using webpack",
+  "main": "index.js",
+  "scripts": {
+    "build": "`npm bin`/webpack",
+    "federalist": "npm run build",
+    "start": "`npm bin`/webpack-dev-server" 
+  },
+  "author": "Jonathan Hooper",
+  "license": "ISC",
+  "dependencies": {
+    "webpack": "^1.14.0"
+  },
+  "devDependencies": {
+    "webpack-dev-server": "^1.16.2"
+  }
+}
+```
+
+## Specifying a Node version
+
+Federalist uses [Node Version Manager](https://github.com/creationix/nvm) to track the node version your site is meant to use.
+Before running any npm commands, Federalist checks for a file named `.nvmrc`.
+If it finds one, it will use NVM to install and use the desired node version before continuing.


### PR DESCRIPTION
This commit documents how site owners can use Node.js with Federalist.

Note that the features described in this commit will not take effect
until 18F/federalist-docker-build#13 and 18F/federalist#680 are merged.