### PR TITLE
Add note about trailing slash

### DIFF
--- a/pages/how-federalist-works/custom-urls.md
+++ b/pages/how-federalist-works/custom-urls.md
@@ -15,7 +15,7 @@ To get the URLs and HTTPS to work for your production site, there are a few tech
 
  - Confirm you are ready for your site to go-live at its permanent URL (this URL process needs to happen within a few hours timespan when started).
  - The Federalist team uses the cloud.gov CloudFront broker to begin set up for a distribution for a given URL.
-  - We'll do this by accessing our org in cloud.gov and running the command `cf create-service cdn-route cdn-route YOUR.URL.gov-route -c '{"domain": "YOUR.URL.gov", "origin": "federalist-proxy.app.cloud.gov", "path": "/site/<org>/<repo-name>"}'`.
+  - We'll do this by accessing our org in cloud.gov and running the command `cf create-service cdn-route cdn-route YOUR.URL.gov-route -c '{"domain": "YOUR.URL.gov", "origin": "federalist-proxy.app.cloud.gov", "path": "/site/<org>/<repo-name>"}'`. Note that the path argument here does not have a trailing slash.
  - After running the command above, the command `cf service YOUR.URL.gov-route` is used to retrieve the CloudFront URL to be used in DNS changes. We'll communicate that URL to you as needed.
  - You, our partner, set your DNS records with a CNAME to delegate the subdomain (e.g. yourprogram.youragency.gov) to the CloudFront distribution URL (e.g. d2oezh1w8w4o1u.cloudfront.net).
    - It takes roughly 30 minutes for the d2oezh1w8w4o1u.cloudfront.net-style URL to start pointing at your specified origin/path. Once yourprogram.youragency.gov shows your site content (perhaps without images or CSS) under the correct HTTPS certificate, you'll know the CloudFront delegation process is complete.


### PR DESCRIPTION
This adds a note about trailing slashes to the instructions for setting custom URLs.