### PR TITLE
Add max-width for list items in main content area

### DIFF
--- a/assets/css/uswds-overrides.css
+++ b/assets/css/uswds-overrides.css
@@ -1,6 +1,6 @@
 ---
 # build this file as raw CSS
-layout: none
+layout: null
 ---
 {% if site.logo.url %}
 .usa-logo-text {
@@ -11,3 +11,11 @@ layout: none
   background-size: 1em;
 }
 {% endif %}
+
+.usa-content {
+
+  ul,
+  ol {
+    max-width: 53rem;
+  }
+}


### PR DESCRIPTION
This fixes the issue around inconsistent line widths on list items when using the Standards. [We currently have an issue opened](https://github.com/18F/web-design-standards/issues/1682) for making this fix on the main code base. Adding this in so that [this pull request](https://github.com/18F/federalist-docs/pull/31) is no longer blocked.

Also, fixed the layout front matter for the override stylesheet to `null` from `none` and made that error going away 🎉 