### PR TITLE
Remove references to the editor

### DIFF
--- a/pages/custom-templates.md
+++ b/pages/custom-templates.md
@@ -1,11 +1,9 @@
 ---
 title: Custom Templates
 ---
-Federalist is a continuous deployment-like build environment for static sites. It works by setting a webhook on your site's GitHub repository and generates your site on each `push` event to that repository. Changes made to the site's content and files in its repository through the Federalist web editor or otherwise launch rebuild tasks of the site in a build environment container.
+Federalist is a continuous deployment-like build environment for static sites. It works by setting a webhook on your site's GitHub repository and generates your site on each `push` event to that repository. Changes made to the site's content and files in its repository through the GitHub web editor or otherwise launch rebuild tasks of the site in a build environment container.
 
 If you don't want to use the Federalist templates, you can add your own GitHub repository to build a completely custom site. When you add a repository-based site, you can choose your build engine: Jekyll, Hugo (not yet implemented), or static, which simply pushes the files in your repository. You can also specify a default branch of your repository to serve as the "production" version of the site.
-
-Federalist is designed to be a modular service. Some people customize their sites by creating new templates that work with the Federalist web editor. Others only use the Federalist build process, managing their content with GitHub. When used this way Federalist acts a no-configuration, production-ready hosting solution for GitHub-based static websites on 18F infrastructure with a custom domain. 
 
 ## Jekyll resources
 
@@ -25,64 +23,6 @@ Federalist adds a `site.branch` attribute to your global site object with the va
 
 Federalist also adds information about the git commit at which the site was built. Access this information through `site.commit`. The commit object includes `site.commit.commit` (the SHA), `site.commit.author`, `site.commit.date`, and `site.commit.message`.
 
-### Content editor
-
-Federalist provides a web-based content editor. To best take advantage of the content editor, content files should be in standard Markdown, with files ending in `.md`. When users open a Markdown file on Federalist, they will see a simple rich text editor with inline formatting for font styles, links, images, and lists.
-
-The rich editor is still in development and does not handle embedded HTML or non-standard elements. If unsupported content is present, the content editor will switch to plain text mode for editing raw Markdown files.
-
-If users open a file with a `.html` extension, they will be redirected to the editor on GitHub.com.
-
-### Navigation menu
-
-Federalist will show a file listing for any repository/project that is added to it. By default, this listing includes all of the files in the project, and users can browse through them. As part of our effort to break away from `git` paradigms for content editors and simplify content management, we lay out the file listing in a more usable way. Instead of showing "files", we prefer to show the user only the "pages" with content that they can edit.
-
-Federalist looks for a `_navigation.json` file in the root of a project to denote which files are "pages" that a content manager would care about. This file can be generated in any form, though for Jekyll sites it is likely best if `_navigation.json` is generated dynamically after each build so that it stays current and up to date.
-
-Since Jekyll does not generate files that start with an underscore, be sure to add `_nagivation.json` to your `_config.yml` file under the `include` block:
-
-    include:
-      - _navigation.json
-
-The schema for `_navigation.json` is simple.
-
-Each "page" must have:
-
-1. A `title` value, which should be a string. This will be the title shown to the user of the page in the listing.
-
-2. An `href` value, which should point to the respective "file". This link will be displayed as "Edit" in Federalist and should link the user to the proper file, loaded into the editor. The value should not begin with a "/" and should be a relative URL from the root of the project structure (not the generated output).
-
-A "page" may have the following:
-
-1. A `children` value, which should be an array of pages. This explains hierarchy to Federalist so that pages can be shown under their conceptual parents.
-
-Here is an example of a small `_navigation.json`:
-
-    [
-      {
-        "title": "About",
-        "href": "pages/about.md"
-      },
-      {
-        "title": "Approach",
-        "href": "pages/approach.md"
-      },
-      {
-        "title": "Work",
-        "href": "pages/work.md",
-        "children": [
-          {
-            "title": "Project 1",
-            "href": "pages/projects/microloans-for-farmers.md"
-          },
-          {
-            "title": "Project 2",
-            "href": "pages/projects/reducing-summer-melt.md"
-          }
-        ]
-      }
-    ]
-
 ### Metadata defaults
 
 If you [specify front-matter defaults](http://jekyllrb.com/docs/configuration/#front-matter-defaults) in your Jekyll site configuration, Federalist will pre-fill the front-matter of a new post with these defaults.
@@ -91,7 +31,7 @@ If you [specify front-matter defaults](http://jekyllrb.com/docs/configuration/#f
 
 To handle routing sites for previews, Federalist automatically sets a `baseurl` path for your site. This essentially nests your site in a subdirectory under the `federalist.18f.gov` domain, such as `federalist.18f.gov/preview/18f/hub/new-draft`, where `/preview/18f/hub` is the `baseurl`.
 
-All links to other pages or resources on the site require a `baseurl` prefix. The Federalist editor takes care of this when users create links or embed images. If you're designing a custom template to work with Federalist, make sure all references to relative links include `site.baseurl` prefixes, including trailing slashes, as follows:
+All links to other pages or resources on the site require a `baseurl` prefix. If you're designing a custom template to work with Federalist, make sure all references to relative links include `site.baseurl` prefixes, including trailing slashes, as follows:
 
 Link: `{% raw %}[About Us]({{site.baseurl}}/about-us){% endraw %}`
 

--- a/pages/index.md
+++ b/pages/index.md
@@ -15,7 +15,7 @@ Federalist generates static websites instead of using a more complex content man
 
 - **Less complexity and vulnerability** Avoiding CMSs means avoiding problems like maintaining dynamic server applications (no PHP or Apache / IIS) and database scaling and redundancy. Production-level static sites generally require one simple static file server or service as opposed to dozens. This means that the whole website is easier to maintain and has fewer vulnerabilities.
 
-- **Update content without writing code** Static websites store content in simple text files that anyone on the team can edit. The Federalist editor provides a way for basic editing of these files without needing to write code.
+- **Update content without writing code** Static websites store content in simple text files that anyone on the team can edit. The GitHub editor provides a way for basic editing of these files without needing to write code.
 
 - **Easy to host and maintain** It’s very easy to host static website files. You can easily take advantage of scaling services like Amazon S3 where you pay only for what you use.
 
@@ -23,7 +23,7 @@ Federalist generates static websites instead of using a more complex content man
 
 ## What can I build with Federalist?
 
-Federalist provides [ready-to-use templates]({{site.baseurl}}/pages/using-federalist/#federalist-templates) for several common website types. You can also use custom website templates based on Jekyll. 18F maintains many Jekyll-based websites that you can fork and adopt, though some must be edited directly (not via the Federalist editor).
+Federalist provides [ready-to-use templates]({{site.baseurl}}/pages/using-federalist/#federalist-templates) for several common website types. You can also use custom website templates based on Jekyll. 18F maintains many Jekyll-based websites that you can fork and adopt.
 
 Possible sites include:
 

--- a/pages/using-federalist.md
+++ b/pages/using-federalist.md
@@ -26,30 +26,6 @@ Federalist provides templates for common websites. Here are the templates curren
 
 Additionally, Federalist will build any Jekyll-based website, supporting [custom website templates]({{site.baseurl}}/pages/custom-templates/).
 
-## Editing content
-
-The Federalist web editor is a simplified tool for editing your website content directly from your web browser. After opening a site in the editor, you will see all of the files that make up your website. The `pages` folder holds the content that people visiting your website will see. You can select any page in this folder to edit its content.
-
-The rich text editor gives you a toolbar for formatting options including links, lists, and header styles.
-
-Your site should be drafted using links like this: `[Our Work]({{site.baseurl}}/work/)`. The "site.baseurl" framing allows multiple versions of the links to be built on preview copies of the site without interfering with the live site.  Enter text in the main field. Highlight text and select a formatting option to apply it. The arrow buttons undo and redo changes. 
-
-You can use the editor to uploaded new images and insert images that you've already uploaded. The image button opens a browser of past images. Selecting one adds it to the page's content. Please note that image support is not as robust as in a full CMS.
-
-
-### Page settings
-
-Page settings give you control of additional elements of a page's design, including its title, layout, and URL (for example, you might set the URL to `/about/` in order for the page to be accessible at `www.xyz.gov/about`). Some templates have unique settings that show up here as well. For instance, the "modern homepage" template allows you to set a feature image for some pages within page settings.
-
-
-### Saving changes
-
-The save button will store any changes you made to content or settings on a page. There is an optional field to enter a log message describing your changes. This log message is useful for reviewing the history of changes to a page.
-
-When you save a page, Federalist will automatically rebuild your site to publish the new changes to the internet. This process may take some time, depending on your site template. By returning to the site listing page, you may view the latest version of your site or check the log to see the status of recent builds.
-
-If you save a page as a draft, Federalist will provide a button to view the draft page. For those making edits directly in GitHub, the drafts are available for preview (with Federalist login) at `https://federalist.18f.gov/preview/:owner/:repo/:branch/`.
-
 ## Content strategy
 
 The first step to building a new site is to map a strategy for the site's content. 18F provides several resources to assist with this process.

--- a/pages/using-federalist/customer-responsibilities.md
+++ b/pages/using-federalist/customer-responsibilities.md
@@ -5,7 +5,7 @@ parent: Using Federalist
 
 ## Your Responsibilities when using Federalist
 
-Using Federalist places certain responsibilities on you as the government user of Federalist. GSA has many internal sites running on Federalist, but GSA cannot guarantee that Federalist is compatable with your agency's specific policies. 
+Using Federalist places certain responsibilities on you as the government user of Federalist. GSA has many internal sites running on Federalist, but GSA cannot guarantee that Federalist is compatable with your agency's specific policies.
 
 Federalist retains other responsibilities, clarified below. The intent of these policies is to empower you to use Federalist to its full potential with awareness of your responsibilities when using advanced features.
 
@@ -17,7 +17,7 @@ GitHub is used across the government (see [this dashboard](https://gsa.github.io
 
 #### You own your content
 
-Federalist provides templates for you to start with in configuring your sites, but is not responsible for editing or updating the content or local configuration of your site. The Federalist team ensures that the publishing mechanism and editor remain available to you so that your content edits can be published immediately.
+Federalist provides templates for you to start with in configuring your sites, but is not responsible for editing or updating the content or local configuration of your site. The Federalist team ensures that the publishing mechanism remain available to you so that your content edits can be published immediately.
 
 Federalist suggests that you add your 18F point of contact to your repo with editing rights for troubleshooting purposes, but this is not required.
 


### PR DESCRIPTION
This commit removes references to the Federalist editor since the editor has been removed.

Ref 18f/federalist#770