### PR TITLE
Replace SBST.gov with 18f.gsa.gov on the homepage

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -38,8 +38,8 @@ Here are a few examples of Federalist websites in production:
 ![College Scorecard]({{site.baseurl}}/uploads/college-scorecard.png)
 **[The College Scorecard](https://collegescorecard.ed.gov/)**
 
-![SBST.gov]({{site.baseurl}}/uploads/sbst.png)
-**[The Social and Behavioral Sciences Team](https://sbst.gov/)**
+![18f.gsa.gov]({{site.baseurl}}/uploads/partner-sites/18f-gsa-gov.png)
+**[18F Homepage](https://18f.gsa.gov/)**
 
 ## Getting started
 


### PR DESCRIPTION
This commit replaces SBST.gov with 18f.gsa.gov as an example of something you can build with Federalist on the home page.