### PR TITLE
Add instructions on specifying ruby version with RVM

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -84,6 +84,9 @@ navigation:
   - text: Node on Federalist
     url: /pages/how-federalist-works/node-on-federalist/
     internal: true
+  - text: RVM on Federalist
+    url: /pages/how-federalist-works/rvm-on-federalist/
+    internal: true
   - text: Deploying Federalist
     url: /pages/how-federalist-works/deploying-federalist/
     internal: true

--- a/pages/how-federalist-works/rvm-on-federalist.md
+++ b/pages/how-federalist-works/rvm-on-federalist.md
@@ -1,0 +1,12 @@
+---
+title: RVM on Federalist
+parent: How Federalist Works
+---
+
+Federalist uses [RVM](https://rvm.io/) to select which ruby version to use to build a Federalist site.
+
+## Specifying a Ruby version
+
+Prior to building a site, the build will check for a file named `.ruby-version`. If one is found, it will use RVM to install and use the version specified there.
+
+For example, if you wish to use Ruby version 2.4.0 to build a site, add a new file named `.ruby-version` to your repository. The `.ruby-version` file should be at the top-level directory. The contents of that file should be "`2.4.0`".


### PR DESCRIPTION
This commit adds instructions on how to use RVM to specify a ruby
version for a Federalist site.