### PR TITLE
Use correct URL for federalist-builder

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,9 +1,10 @@
 
-<footer class="usa-footer usa-footer-medium" role="contentinfo">
-  <div class="usa-grid usa-footer-return-to-top">
-    <a href="#">Return to top</a>
-  </div>
-  <div class="usa-grid usa-footer-return-to-top">
-    <a href="https://github.com/18f/federalist-docs/edit/master/{{ page.path }}">Edit on GitHub</a>
+
+<footer class="usa-footer usa-footer-medium site" role="contentinfo">
+  <div class="usa-footer-primary-section">
+    <div class="usa-grid">
+      <p><a href="#">Return to top</a></p>
+      <p><a href="https://github.com/18f/federalist-docs/edit/master/{{ page.path }}">Edit on GitHub</a></p>
+    </div>
   </div>
 </footer>

--- a/pages/how-federalist-works.md
+++ b/pages/how-federalist-works.md
@@ -71,7 +71,7 @@ Message queue for handling build requests
 - federalist-builds
 
 
-### https://federalist-builder.18f.gov
+### https://federalist-builder.fr.cloud.gov
 
 Processes build requests from a queue and launches build tasks
 


### PR DESCRIPTION
Also slight styling adjustment to the footer to differentiate it from main content. Looks like this now:

<img width="1127" alt="screen shot 2017-06-23 at 9 27 40 am" src="https://user-images.githubusercontent.com/697848/27486521-7e97fd5a-57f6-11e7-938f-35d9103b860f.png">

