### PR TITLE
Add link to site header and add site.title value

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,8 @@ author:
 logo:
   url: /uploads/logo.svg
 
+title: Federalist Docs
+
 # Navigation
 # List links that should appear in the site sidebar here
 navigation:

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -8,7 +8,7 @@
     <button class="usa-menu-btn">Menu</button>
     <div class="usa-logo" id="logo">
       <em class="usa-logo-text">
-        <a href="#" accesskey="1" title="Home" aria-label="Home">{{ site.name }}</a>
+        <a href="{{ site.baseurl }}/" accesskey="1" title="Home" aria-label="Home">{{ site.name }}</a>
       </em>
     </div>
   </div>


### PR DESCRIPTION
Fix the main header link to point to the site root.

Also add the `site.title` value so that the title attribute doesn't look weird any more:

<img width="230" alt="screen shot 2017-10-06 at 12 14 00 pm" src="https://user-images.githubusercontent.com/697848/31294608-5fedb27c-aa90-11e7-8c35-f877c7136653.png">

`->`

<img width="238" alt="screen shot 2017-10-06 at 12 15 38 pm" src="https://user-images.githubusercontent.com/697848/31294612-6680a2e8-aa90-11e7-84b4-e265f30ed1a0.png">

ref #144 