### PR TITLE
remove docker-ruby-ubuntu mentions

### DIFF
--- a/pages/how-federalist-works/how-builds-work.md
+++ b/pages/how-federalist-works/how-builds-work.md
@@ -47,9 +47,9 @@ Jekyll has a plugin system for adding custom features to the build process of yo
 
 Federalist supports Jekyll plugins, enabling any plugins in a site's `_plugins` directory. If the site includes a `Gemfile`, Federalist will also run `bundle install && bundle exec jekyll build` to install required Ruby gems and generate the site with those libraries available for use in plugins. You can also use a `Gemfile` to change the version of Jekyll used to build the site.
 
-Several dependencies are already available for use in the building environment. These include `ruby`, `python`, and `node.js`, as well as the [`github-pages` gem](https://pages.github.com/versions/), which includes several common gems used for building sites. You can write plugins that take advantage of these without needing a `Gemfile`.
+Several dependencies are already available for use in the building environment. These include `ruby`, `python`, and `node.js`. You can write plugins that take advantage of these without needing a `Gemfile`.
 
-To see the exact configuration of the build environment, see the [build environment `Dockerfile`](https://github.com/18F/federalist-garden-build/blob/master/Dockerfile) and [base image `Dockerfile`](https://github.com/18F/docker-ruby-ubuntu/blob/master/Dockerfile).
+To see the exact configuration of the build environment, see the [build environment `Dockerfile`](https://github.com/18F/federalist-garden-build/blob/master/Dockerfile).
 
 **Note:** using `Gemfile` may considerably slow down the generation of your website, depending on how long the `bundle install` step takes to complete.
 

--- a/pages/how-federalist-works/index.md
+++ b/pages/how-federalist-works/index.md
@@ -14,8 +14,8 @@ We use GitHub to manage our work on Federalist. The main code repository for the
 - **[federalist](https://github.com/18F/federalist)** This is the core application for Federalist and contains the frontend interface as well as the code that interacts with the GitHub API and sets up new Federalist sites, including a Github webhook that triggers messages into the build queue through the app. It has two cloud.gov service instances (redis and rds) for session storage and persistent data storage of users, sites, and logs.
 - **[federalist-builder](https://github.com/18F/federalist-builder)** This application launches build tasks for Federalist in a Linux Garden container based on messages from a queue and contains scheduling logic.
 - **[federalist-proxy](https://github.com/18F/federalist-proxy)** This application serves as a proxy for the S3 bucket to which Federalist deploys static content. It adds some required headers for compliance.
-- **[federalist-garden-build](https://github.com/18F/federalist-garden-build)** Pulling from docker-ruby-ubuntu, this container image adds the dependencies and scripts for a Garden Linux container to build out a Federalist site.
-- **[docker-ruby-ubuntu](https://github.com/18F/docker-ruby-ubuntu)** Container image specification to run in a Garden Linux container.
+- **[federalist-garden-build](https://github.com/18F/federalist-garden-build)** This container image contains the code to build Federalist sites in Garden Linux containers.
+
 
 ### Templates and Documentation
 


### PR DESCRIPTION
That base container image is no longer used in our garden build container. Ref #187.

Also removed a bit about the `github-pages` gem being pre-installed. It's not as far as I can tell, and I'm not sure if it ever was :) @jmhooper?