### PR TITLE
Add detail re: templates

### DIFF
--- a/pages/using-federalist/templates.md
+++ b/pages/using-federalist/templates.md
@@ -18,7 +18,9 @@ templates:
 
 # Templates
 
-Federalist provides templates for common website types. Here are the templates currently available:
+Federalist offers several templates for common website types that are meant to serve as a starting point for you. These templates show what’s possible and can even be the basis for your site if your needs are closely aligned to the formatting of the template. Federalist templates are not built to serve as final work products, nor are they like templates that you might typically find in a content management system. Instead, templates serve as a “starter kit.” Substantial configuration of a Federalist template requires technical knowledge and know-how.
+
+Here are the templates currently available:
 
 {% for tem in page.templates %}
   <h3>{{ tem.title }}</h3>


### PR DESCRIPTION
The templates page currently displays the templates offered. This PR adds detail specific to how partners should view templates — both what they are and what they are not.