### PR TITLE
Template docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,12 +15,22 @@ dap_agency: GSA
 
 search_site_handle: federalist-docs
 
+collections:
+  templates:
+    output: true
+    permalink: /pages/using-federalist/templates/:name/
+
 defaults:
   - scope:
       path: ""
     values:
       layout: "page"
       sidenav: "sidenav"
+  - scope:
+      path: ""
+      type: templates
+    values:
+      layout: "template"
 
 styles:
   - /assets/css/site.css

--- a/_layouts/template.html
+++ b/_layouts/template.html
@@ -6,6 +6,12 @@ layout: page
 
 <p>{{ page.summary}}</p>
 
+<p>
+  <a class='screenshot' href='{{ page.preview_url }}'>
+    <img src='{{ site.baseurl }}{{ page.img }}' alt='Screenshot of the {{ page.title }}'>
+  </a>
+</p>
+
 <p><a href="{{ page.preview_url }}">Preview the template.</a></p>
 
 <h2>How to use this template</h2>

--- a/_layouts/template.html
+++ b/_layouts/template.html
@@ -1,0 +1,13 @@
+---
+layout: page
+---
+
+<h1>{{ page.title }}</h1>
+
+<p>{{ page.summary}}</p>
+
+<p><a href="{{ page.preview_url }}">Preview the template.</a></p>
+
+<h2>How to use this template</h2>
+
+{{ content }}

--- a/_templates/basic-report.md
+++ b/_templates/basic-report.md
@@ -1,0 +1,19 @@
+---
+img: /assets/images/templates/federalist-report-template.png
+order: 4
+preview_url: https://federalist-proxy.app.cloud.gov/preview/18f/federalist-uswds-template/report-config/
+summary: |
+  The basic report template is a simple, easy to use setup designed to host
+  multiple pages about a recent report or order. This setup provides a clean space
+  for complex details or instructions. Navigation can be customized to host many
+  pages while maintaining a clear hierarchy.
+title: Basic Report Template
+---
+
+{% comment %}
+"How to use" documentation goes here in the document body.
+{% endcomment %}
+
+Put your PDF report under `/assets/docs` and update the secondary href in `_data/navigation.yml`.
+
+You can update the content or add new pages by updating the files under `pages`.

--- a/_templates/landing-page.md
+++ b/_templates/landing-page.md
@@ -1,0 +1,10 @@
+---
+title: Landing Page Template
+preview_url: https://federalist-landing-template.18f.gov/
+docs_url: https://github.com/18F/federalist-landing-page-template
+img: /assets/images/templates/federalist-landing-template.png
+order: 3
+---
+{% comment %}
+"How to use" documentation goes here in the document body.
+{% endcomment %}

--- a/_templates/modern-team.md
+++ b/_templates/modern-team.md
@@ -1,0 +1,10 @@
+---
+title: Modern Team Template
+docs_url: https://github.com/18f/federalist-modern-team-template
+preview_url: https://federalist-modern-team-template.18f.gov/
+img: /assets/images/templates/federalist-modern-team-template.png
+order: 2
+---
+{% comment %}
+"How to use" documentation goes here in the document body.
+{% endcomment %}

--- a/_templates/uswds-default.md
+++ b/_templates/uswds-default.md
@@ -1,0 +1,10 @@
+---
+title: U.S. Web Design Standards Landing and Docs Template
+docs_url: https://github.com/18f/federalist-uswds-template/
+preview_url: https://federalist-uswds-template.18f.gov/
+img: /assets/images/templates/federalist-uswds-template.png
+order: 1
+---
+{% comment %}
+"How to use" documentation goes here in the document body.
+{% endcomment %}

--- a/pages/using-federalist/templates.md
+++ b/pages/using-federalist/templates.md
@@ -14,7 +14,7 @@ Here are the templates currently available:
   <h3>{{ tem.title }}</h3>
   <p>
     <a class='screenshot' href='{{ tem.preview_url }}'>
-      <img src='{{ site.baseurl }}{{ tem.img }}' alt='{{ tem.title }}'>
+      <img src='{{ site.baseurl }}{{ tem.img }}' alt='Screenshot of the {{ tem.title }}'>
     </a>
   </p>
   <p>

--- a/pages/using-federalist/templates.md
+++ b/pages/using-federalist/templates.md
@@ -23,7 +23,8 @@ Here are the templates currently available:
       If the docs live outside of federalist docs, use docs_url, otherwise use
       the url for the template's docs page.
     {% endcomment %}
-    <a href="{{ tem.docs_url | default: tem.url }}">Read the template documentation.</a>
+    {% assign default_docs_url = tem.url | prepend: site.baseurl %}
+    <a href="{{ tem.docs_url | default: default_docs_url }}">Read the template documentation.</a>
   </p>
 {% endfor %}
 

--- a/pages/using-federalist/templates.md
+++ b/pages/using-federalist/templates.md
@@ -1,20 +1,8 @@
 ---
 title: Templates
 permalink: /pages/using-federalist/templates/
-templates:
-- title: U.S. Web Design Standards Landing and Docs Template
-  url: https://github.com/18f/federalist-uswds-template/
-  img: /assets/images/templates/federalist-uswds-template.png
-- title: Modern Team Template
-  url: https://github.com/18f/federalist-modern-team-template
-  img: /assets/images/templates/federalist-modern-team-template.png
-- title: Landing Page Template
-  url: https://github.com/18F/federalist-landing-page-template
-  img: /assets/images/templates/federalist-landing-template.png
-- title: Basic Report Template
-  url: https://github.com/18F/federalist-report-template
-  img: /assets/images/templates/federalist-report-template.png
 ---
+{% assign templates = site.templates | sort: 'order' %}
 
 # Templates
 
@@ -22,12 +10,20 @@ Federalist offers several templates for common website types that are meant to s
 
 Here are the templates currently available:
 
-{% for tem in page.templates %}
+{% for tem in templates %}
   <h3>{{ tem.title }}</h3>
   <p>
-    <a class='screenshot' href='{{ tem.url }}'>
+    <a class='screenshot' href='{{ tem.preview_url }}'>
       <img src='{{ site.baseurl }}{{ tem.img }}' alt='{{ tem.title }}'>
     </a>
+  </p>
+  <p>
+    {% comment %}
+      TODO: move all the template docs that we support to federalist-docs.
+      If the docs live outside of federalist docs, use docs_url, otherwise use
+      the url for the template's docs page.
+    {% endcomment %}
+    <a href="{{ tem.docs_url | default: tem.url }}">Read the template documentation.</a>
   </p>
 {% endfor %}
 


### PR DESCRIPTION
From https://github.com/18F/federalist-uswds-template/pull/19#issuecomment-380281122, we decided that if Federalist provides official support for the templates, then the documentation should live with the official Federalist documentation vs on a wiki or GitHub README.

This introduces a Jekyll collection for the template pages.

We now include a link to the documentation on the template index page.
![screenshot from 2018-04-12 09-51-14](https://user-images.githubusercontent.com/509703/38692453-a404de54-3e38-11e8-85d8-a86c15bf9d7d.png)

Here's what the Basic Report doc page looks like.
![screencapture-localhost-4000-pages-using-federalist-templates-basic-report-2018-04-12-10_03_30](https://user-images.githubusercontent.com/509703/38692519-cb3d92a4-3e38-11e8-8343-aeda69a688ac.png)